### PR TITLE
Avoid adding face properties to ido-matches

### DIFF
--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -133,6 +133,12 @@ so we can restore it when turning `ido-vertical-mode' off")
           (setq comps (append comps (make-list (- (1+ ido-max-prospects) lencomps) "")))))
 
     (when ido-use-faces
+      ;; Make a copy of [ido-matches], otherwise the selected string
+      ;; could contain text properties which could lead to weird
+      ;; artifacts, e.g. buffer-file-name having text properties.
+      (when (eq comps ido-matches)
+        (setq comps (copy-sequence ido-matches)))
+
       (dotimes (i ido-max-prospects)
         (setf (nth i comps) (substring (if (listp (nth i comps))
                                            (car (nth i comps))


### PR DESCRIPTION
Fixes #26

Code is using **setf** which means that **ido-matches** is directly changed to have strings with text-properties. The usual case is that the head of **ido-matches** is returned as the selected item which can then lead to all sorts of weird things as I complained in issue #26. This fixes the issue by simply copying **ido-matches**. It's possible that something more efficient can be done by avoiding **setf** in the first place but I wanted to make as small change as possible. 